### PR TITLE
Add documentation on how to add modules

### DIFF
--- a/ADD_MODULES.md
+++ b/ADD_MODULES.md
@@ -1,0 +1,21 @@
+# Documentation on how to add new modules
+
+Adding new modules to your lesson is quite ease. 
+
+1. The first step consists of creating a new folder inside the main `modules` directory with the name of your new module, say, `my_new_module`.
+
+2. Inside `my_new_module`, we need to create an additional file named `index.md`. An example of a `index.md` file can be given below
+ ```
+ ---
+ id: 0
+ trl: medium
+ category: Category1
+ title: Title of module 1
+ author: eScience Center
+ thumbnail: "nlesc-dummy.png"
+ visibility: visible
+ ---
+ 
+ # Title of module 1
+ ```
+ 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can modify the `"title"` field to reflect your specific topic and add new se
 The `"repoName"` and `"baseURL"` fields are automatically updated to the name of your new repository using the [generate_config.yml](https://github.com/esciencecenter-digital-skills/NEBULA-content-template/blob/main/.github/workflows/generate_config.yml) file. The corresponding workflow is triggered only once upon repository instantiation and is subsequently disabled.
 
 ## Adding new modules
-This repository includes dummy model modules as templates that you can follow to create your own modules. Please, follow the recommended formats and file extensions.
+This repository includes dummy model modules as templates that you can follow to create your own modules. Please, follow the recommended formats and file extensions. See also [here](ADD_MODULES.md) for information on how to create new modules.
 
 ## Suggestions and further info
 Suggestions are always welcome.


### PR DESCRIPTION
This PR closes https://github.com/esciencecenter-digital-skills/NEBULA-docs/issues/5.

@JaroCamphuijsen. I think it would make more sense to add this info here, but I am open to suggestions; we could later on move the created `ADD_MODULE.md` file to https://github.com/esciencecenter-digital-skills/research-software-support or alternatively include this file in https://github.com/esciencecenter-digital-skills/research-software-support/blob/main/README.md. 

## Note
This branch has been checked out from [update_module_format](https://github.com/esciencecenter-digital-skills/NEBULA-content-template/tree/update_module_format) and could be merged after it.